### PR TITLE
don't leak file descriptor in error cases

### DIFF
--- a/compress42.c
+++ b/compress42.c
@@ -888,7 +888,7 @@ comprexx(fileptr)
 	char	**fileptr;
 	{
 		int		fdin;
-		int		fdout;
+		int		fdout = -1;
 		char	tempname[MAXPATHLEN];
 
 		if (strlen(*fileptr) > sizeof(tempname) - 3) {
@@ -1052,8 +1052,7 @@ comprexx(fileptr)
 							statbuf.st_ctime == statbuf2.st_ctime)
 						{
 							fprintf(stderr, "%s: filename too long to tack on .Z\n", tempname);
-							exit_code = 1;
-							return;
+							goto error;
 						}
 
 						ofname[s-1] = (char)c;
@@ -1092,8 +1091,7 @@ comprexx(fileptr)
 		    			if (inbuf[0] != 'y')
 						{
 							fprintf(stderr, "%s not overwritten\n", ofname);
-							exit_code = 1;
-							return;
+							goto error;
 		    			}
 					}
 
@@ -1101,15 +1099,14 @@ comprexx(fileptr)
 					{
 						fprintf(stderr, "Can't remove old output file\n");
 						perror(ofname);
-						exit_code = 1;
-						return ;
+						goto error;
 					}
 				}
 
 		    	if ((fdout = open(ofname, O_WRONLY|O_CREAT|O_EXCL|O_BINARY,0600)) == -1)
 				{
 			      	perror(tempname);
-					return;
+					goto error;
 		    	}
 
 				if ((s = strlen(ofname)) > 8)
@@ -1118,8 +1115,7 @@ comprexx(fileptr)
 					{
 						fprintf(stderr, "Can't get status op output file\n");
 						perror(ofname);
-						exit_code = 1;
-						return ;
+						goto error;
 					}
 
 					c = ofname[s-1];
@@ -1144,8 +1140,7 @@ comprexx(fileptr)
 							fprintf(stderr, "can't remove bad output file\n");
 							perror(ofname);
 						}
-						exit_code = 1;
-						return;
+						goto error;
 					}
 
 					ofname[s-1] = (char)c;
@@ -1271,6 +1266,14 @@ comprexx(fileptr)
 			  		tempname);
 	  		break;
 		}
+
+		return;
+
+error:
+		exit_code = 1;
+		close(fdin);
+		if (fdout != -1)
+			close(fdout);
 	}
 
 #ifdef	RECURSIVE


### PR DESCRIPTION
This was wasting fd numbers if ncompress operated recursively.