### PR TITLE
fixed nine bits processing, updated reset code behaviour

### DIFF
--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -174,4 +174,9 @@ uncompress -k i
 [ -e i -a -e i.Z ]
 rm i.Z
 
+: "### Check nine bits on large input"
+compress -b 9 <$COMPRESS >input.Z
+uncompress -c input.Z >input.new
+cmp $COMPRESS input.new
+
 : "### All passed!"


### PR DESCRIPTION
Closes #5.

Please review small pr, it fixes nine bits processing. The problem is that `extcode` and `maxcode` together with `n_bits` were not properly initialized and reset. I've added code in the same style as code around.

We may create macro like `reset_n_bits_for_compressor` and `reset_n_bits_for_decompressor` instead of just copying code twice.