### PR TITLE
Avoid underflowing access to in inbuf.

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -1391,6 +1391,7 @@ resetbuf:	;
 
 						posbits -= n_bits;
 						p = &inbuf[posbits>>3];
+						if (p == inbuf) p++;
 
 						fprintf(stderr, "insize:%d posbits:%d inbuf:%02X %02X %02X %02X %02X (%d)\n", insize, posbits,
 								p[-1],p[0],p[1],p[2],p[3], (posbits&07));


### PR DESCRIPTION
This fixes an out of bounds memory access in some error cases.

Here's a minified base64 encoded testcase:
```
H52QMDAwMDAwDjAwMDAwMDAwBDAwMDAwMDAwDTAwMDAwMAEwMDAwMBs=
```

The bug can be triggered by compiling ncompress with asan and passing above testcase to "compress -dc".

The problem here is that the error message in line 1395 (compress.c) tries to display one byte left of the affected area, but if p starts at position 0 of inbuf this is invalid memory. I'm avoiding this by increasing p by one if this is the case. (It's debatable whether that's the best fix and there are obviously other ways, but it seems simple enough and fixes the issue.)