### PR TITLE
compress.c: fix -std=c23 build failure (signal handler protos)

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -49,10 +49,6 @@
 	};
 #endif
 
-#ifndef SIG_TYPE
-#	define	SIG_TYPE	void (*)()
-#endif
-
 #if defined(AMIGA) || defined(DOS) || defined(MINGW) || defined(WINDOWS)
 #	define	chmod(pathname, mode) 0
 #	define	chown(pathname, owner, group) 0
@@ -327,6 +323,7 @@ static void decompress(int, int);
 static void read_error(void);
 static void write_error(void);
 static void abort_compress(void);
+static void abort_compress_handler(int);
 static void prratio(FILE *, long, long);
 static void about(void);
 
@@ -379,14 +376,14 @@ main(int argc, char *argv[])
 
 #ifdef SIGINT
 		if ((fgnd_flag = (signal(SIGINT, SIG_IGN)) != SIG_IGN))
-			signal(SIGINT, (SIG_TYPE)abort_compress);
+			signal(SIGINT, abort_compress_handler);
 #endif
 
 #ifdef SIGTERM
-		signal(SIGTERM, (SIG_TYPE)abort_compress);
+		signal(SIGTERM, abort_compress_handler);
 #endif
 #ifdef SIGHUP
-		signal(SIGHUP, (SIG_TYPE)abort_compress);
+		signal(SIGHUP, abort_compress_handler);
 #endif
 
 #ifdef COMPATIBLE
@@ -1487,6 +1484,14 @@ abort_compress(void)
 	    	unlink(ofname);
 
 		exit(1);
+	}
+
+
+void
+abort_compress_handler(int signo)
+	{
+		(void)signo;
+		abort_compress();
 	}
 
 void


### PR DESCRIPTION
gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `ncompress` fails the build as:

    compress.c: In function 'main':
    compress.c:382:40: error:
      passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
      382 |                         signal(SIGINT, (SIG_TYPE)abort_compress);
          |                                        ^~~~~~~~~~~~~~~~~~~~~~~~
          |                                        |
          |                                        void (*)(void)
    In file included from compress.c:30:
    ...-glibc-2.40-36-dev/include/signal.h:88:57: note:
      expected '__sighandler_t' {aka 'void (*)(int)'} but argument is of type 'void (*)(void)'
       88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
          |                                          ~~~~~~~~~~~~~~~^~~~~~~~~

The change removes type casts around function prototypes and define signal handler as `void(*)(int)`.